### PR TITLE
docs: update readme (git.io deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Other implements for programming:
 ## Install
 
 ```bash
-$ curl -sSL https://git.io/JcGER | bash
+$ curl -sSL https://raw.githubusercontent.com/huacnlee/autocorrect/main/install | bash
 ```
 
 after that, you will get `/usr/local/bin/autocorrect` command.


### PR DESCRIPTION
* Git.io deprecation
* https://github.blog/changelog/2022-04-25-git-io-deprecation/