### PR TITLE
fix(Markdown): Avoid add space on WikiLinks

### DIFF
--- a/autocorrect/grammar/markdown.pest
+++ b/autocorrect/grammar/markdown.pest
@@ -1,13 +1,13 @@
 item = _{ SOI ~ line* ~ EOI }
 line = _{ expr | text | newline }
 
-inline = _{ img | link | mark }
+inline = _{ img | link | mark | wikilinks}
 block = ${ PUSH(block_prefix) ~ space ~ inline* ~ string }
 
 expr = _{ codeblock | inline | td_tag | block }
 newline = ${ "\n" | "\r" }
 space = @{ (" ")* }
-codeblock = ${ 
+codeblock = ${
   PUSH("```") ~ codeblock_lang ~ codeblock_code ~ PUSH("```")
 }
 codeblock_lang = { ASCII_ALPHA* }
@@ -27,8 +27,10 @@ image_prefix = @{ "!" }
 img = ${ image_prefix ~ link }
 
 link = ${ link_string ~ link_url }
-link_string = { "[" ~ (!("]" | newline) ~ ANY)* ~ "]" } 
+link_string = { "[" ~ (!("]" | newline) ~ ANY)* ~ "]" }
 link_url = { "(" ~ (!(")" | newline) ~ ANY)* ~ ")" }
+
+wikilinks = ${"[[" ~ (!("]]" | newline) ~ ANY)* ~ "]]" }
 
 mark = ${ PUSH(mark_tag) ~ (!(PEEK) ~ string)  ~ PUSH(mark_tag) }
 

--- a/autocorrect/src/code/markdown.rs
+++ b/autocorrect/src/code/markdown.rs
@@ -75,6 +75,7 @@ mod tests {
     
     - ![img图片](https://google.com/a/b/url不处理)
     - [link链接](https://google.com/a/b/url不处理)
+    - 一个[[Wikilinks测试]]示例
     "###;
 
         let expected = r###"
@@ -134,6 +135,7 @@ mod tests {
     
     - ![img 图片](https://google.com/a/b/url不处理)
     - [link 链接](https://google.com/a/b/url不处理)
+    - 一个[[Wikilinks测试]]示例
     "###;
 
         assert_eq!(expected, format_markdown(example).to_string());


### PR DESCRIPTION
try to fix huacnlee/autocorrect#60