### PR TITLE
Add `--quiet` argument for cli #187.

### DIFF
--- a/autocorrect-cli/src/cli.rs
+++ b/autocorrect-cli/src/cli.rs
@@ -30,6 +30,9 @@ pub(crate) struct Cli {
     #[clap(long, help = "Print debug information.")]
     pub debug: bool,
 
+    #[clap(long, short = 'q', help = "Do not print progress information.")]
+    pub quiet: bool,
+
     #[clap(
         name = "FORMAT",
         long = "format",
@@ -105,7 +108,7 @@ pub(crate) enum Commands {
 
 impl Cli {
     pub fn log_level(&self) -> log::LevelFilter {
-        if self.debug {
+        if self.debug && !self.quiet {
             log::LevelFilter::Debug
         } else {
             log::LevelFilter::Info

--- a/autocorrect-cli/src/progress.rs
+++ b/autocorrect-cli/src/progress.rs
@@ -1,23 +1,39 @@
 use owo_colors::OwoColorize;
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    time::SystemTime,
+};
 
-pub fn ok(show: bool) {
-    if show {
-        print!("{}", ".".green());
-        io::stdout().flush().unwrap();
+use crate::{cli::Cli, logger::SystemTimeDuration as _};
+
+pub fn ok(cli: &Cli) {
+    if cli.quiet || !cli.formatter.is_diff() {
+        return;
     }
+
+    write!(io::stdout(), "{}", ".".green()).unwrap();
 }
 
-pub fn warn(show: bool) {
-    if show {
-        print!("{}", ".".yellow());
-        io::stdout().flush().unwrap();
+pub fn warn(cli: &Cli) {
+    if cli.quiet || !cli.formatter.is_diff() {
+        return;
     }
+
+    write!(io::stdout(), "{}", ".".yellow()).unwrap();
 }
 
-pub fn err(show: bool) {
-    if show {
-        print!("{}", ".".red());
-        io::stdout().flush().unwrap();
+pub fn err(cli: &Cli) {
+    if cli.quiet || !cli.formatter.is_diff() {
+        return;
     }
+
+    write!(io::stdout(), "{}", ".".red()).unwrap();
+}
+
+/// print time spend from start_t to now
+pub fn finish(_cli: &Cli, start_t: SystemTime) {
+    log::info!(
+        "AutoCorrect spend time: {}\n",
+        format!("{}ms", start_t.elapsed_millis()).bright_black()
+    );
 }


### PR DESCRIPTION
- Improved the cli print details, add color to total duration.
- Improved progress dot print, avoid immediate print for improved performance.


```
A linter and formatter for help you improve copywriting, to correct spaces, words, punctuations between CJK (Chinese, Japanese, Korean).

Usage: autocorrect [OPTIONS] [FILE]... [COMMAND]

Commands:
  init    Initialize AutoCorrect config file.
  update  Update AutoCorrect to latest version.
  help    Print this message or the help of the given subcommand(s)

Arguments:
  [FILE]...  Target filepath or dir for format. [default: .]

Options:
      --lint               Lint and output problems.
      --fix                Automatically fix problems and rewrite file.
      --debug              Print debug information.
  -q, --quiet              Do not print progress information.
      --format <FORMAT>    Output format. [default: diff] [possible values: diff, json, rdjson]
      --threads <THREADS>  Number of threads, 0 - use number of CPU. [default: 0]
  -c, --config <CONFIG>    Special config file. [default: .autocorrectrc]
      --type <FILETYPE>    Directly use set file type.
      --stdin              Input text from <STDIN>
      --no-diff-bg-color   Disable diff background color for diff output.
  -h, --help               Print help
  -V, --version            Print version
```