### PR TITLE
Fix `space-dash: 0` can't disable bug #186.

### DIFF
--- a/autocorrect/.autocorrectrc.default
+++ b/autocorrect/.autocorrectrc.default
@@ -10,7 +10,7 @@ rules:
   # Add space between ``, when near the CJK.
   space-backticks: 1
   # Add space between dash `-`
-  space-dash: 0
+  space-dash: 1
   # Convert to fullwidth.
   fullwidth: 1
   # To remove space near the fullwidth punctuations.

--- a/autocorrect/src/config/mod.rs
+++ b/autocorrect/src/config/mod.rs
@@ -87,7 +87,7 @@ pub fn load(config_str: &str) -> Result<Config, Error> {
 
     let new_config: Config = CURRENT_CONFIG.write().unwrap().merge(&config)?;
 
-    Ok(new_config)
+    Ok(dbg!(new_config))
 }
 
 #[derive(Debug, Clone)]
@@ -337,7 +337,7 @@ mod tests {
         for (k, v) in config.rules.clone() {
             match k.as_str() {
                 "spellcheck" => assert_eq!(SeverityMode::Warning, v),
-                "space-dash" => assert_eq!(SeverityMode::Off, v),
+                "space-dash" => assert_eq!(SeverityMode::Error, v),
                 _ => assert_eq!(SeverityMode::Error, v),
             }
         }

--- a/autocorrect/src/rule/mod.rs
+++ b/autocorrect/src/rule/mod.rs
@@ -279,7 +279,8 @@ mod tests {
                 "no-space-fullwidth-quote" => true,
             }, "hello 你好 “Quote” 和 ‘Single Quote’ 测试 0"),
             "hello你好 “Quote” 和 ‘Single Quote’ 测试1" => (map!{}, "hello 你好“Quote”和‘Single Quote’测试 1"),
-            "你好-世界" => (map!{"space-dash" => true}, "你好 - 世界"),
+            "你好-世界" => (map!{}, "你好 - 世界"),
+            "世界-你好" => (map!{"space-dash" => true}, "世界-你好"),
         };
 
         for (input, (disable_rules, expect)) in cases {


### PR DESCRIPTION
In the before versions `-` is always will added spaces by other rules. So I changed the `space-dash` rule default to enable, this will keep the compatibility with before behavior.

Now, we can use `space-dash: 0` to disable the `space-dash` rule.