### PR TITLE
Optimize Dockerfile to use `apk add` with `--no-cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --update curl ca-certificates
+RUN apk add --no-cache curl ca-certificates
 
 ADD install /install 
 RUN sh ./install


### PR DESCRIPTION
Change `apk add` to use `--no-cache` instead of `--update` for package installation. This will prevent the package index from being cached and reduce the image size.