### PR TITLE
Update autocorrect-py README.md to fix print syntax

### DIFF
--- a/autocorrect-py/README.md
+++ b/autocorrect-py/README.md
@@ -28,7 +28,7 @@ autocorrect.format_for("let title = 'Hello你好。'", "js")
 # => "let title = 'Hello 你好。'"
 
 result = autocorrect.lint_for("<h1>这是 Heading标题</h1>", "html")
-print result
+print(result)
 # => LintResult(filepath='html', lines=[LineResult { line: 1, col: 5, new: "这是 Heading 标题", old: "这是 Heading标题", severity: Error }], enable=true)
 
 # Load config


### PR DESCRIPTION
顺便一提，为什么通过 `pip install autocorrect-py` 安装的还是 2.9.0，不是最新版呢？
