### PR TITLE
Add `context.codeblock` config to speical enable / disable in codeblock.

### DIFF
--- a/.autocorrectrc.template
+++ b/.autocorrectrc.template
@@ -2,6 +2,10 @@
 rules:
   # Default rules: https://github.com/huacnlee/autocorrect/raw/main/autocorrect/.autocorrectrc.default
   spellcheck: 2
+# Enable or disable in spatial context
+context:
+  # Enable or disable to format codeblock in Markdown or AsciiDoc etc.
+  codeblock: 1
 textRules:
   # Config some special rule for some texts
   # For example, if we wants to let "Hello你好" just warning, and "Hi你好" to ignore

--- a/autocorrect-cli/src/lib.rs
+++ b/autocorrect-cli/src/lib.rs
@@ -175,7 +175,7 @@ where
 
             let mut filetype = autocorrect::get_file_extension(filepath);
             if let Some(ref ftype) = cli.filetype {
-                filetype = ftype.to_owned();
+                filetype = ftype.to_string();
             }
             if !autocorrect::is_support_type(&filetype) {
                 continue;
@@ -262,15 +262,13 @@ where
                 // Exit with code = 1
                 std::process::exit(1);
             }
+        } else if cli.formatter == cli::OutputFormatter::Json {
+            log::info!("{}", autocorrect::json::to_lint_results_json(lint_results));
         } else {
-            if cli.formatter == cli::OutputFormatter::Json {
-                log::info!("{}", autocorrect::json::to_lint_results_json(lint_results));
-            } else {
-                log::info!(
-                    "{}",
-                    autocorrect::rdjson::to_lint_results_rdjson(lint_results)
-                )
-            }
+            log::info!(
+                "{}",
+                autocorrect::rdjson::to_lint_results_rdjson(lint_results)
+            )
         }
     } else if cli.fix {
         progress::finish(&cli, start_t);
@@ -365,11 +363,9 @@ fn lint_and_output(
         progress::warn(cli);
     }
 
-    if cli.formatter.is_diff() {
-        if result.has_error() {
-            log::debug!("{}\n{}", filepath, result.error);
-            return;
-        }
+    if cli.formatter.is_diff() && result.has_error() {
+        log::debug!("{}\n{}", filepath, result.error);
+        return;
     }
 
     results.push(result.clone());

--- a/autocorrect-cli/src/progress.rs
+++ b/autocorrect-cli/src/progress.rs
@@ -1,8 +1,5 @@
 use owo_colors::OwoColorize;
-use std::{
-    io::{self, Write},
-    time::SystemTime,
-};
+use std::time::SystemTime;
 
 use crate::{cli::Cli, logger::SystemTimeDuration as _};
 
@@ -11,7 +8,7 @@ pub fn ok(cli: &Cli) {
         return;
     }
 
-    write!(io::stdout(), "{}", ".".green()).unwrap();
+    print!("{}", ".".green());
 }
 
 pub fn warn(cli: &Cli) {
@@ -19,7 +16,7 @@ pub fn warn(cli: &Cli) {
         return;
     }
 
-    write!(io::stdout(), "{}", ".".yellow()).unwrap();
+    print!("{}", ".".yellow());
 }
 
 pub fn err(cli: &Cli) {
@@ -27,7 +24,7 @@ pub fn err(cli: &Cli) {
         return;
     }
 
-    write!(io::stdout(), "{}", ".".red()).unwrap();
+    print!("{}", ".".red());
 }
 
 /// print time spend from start_t to now

--- a/autocorrect/.autocorrectrc.default
+++ b/autocorrect/.autocorrectrc.default
@@ -23,6 +23,10 @@ rules:
   halfwidth-punctuation: 1
   # Spellcheck
   spellcheck: 0
+# Enable or disable in spatial context
+context:
+  # Enable or disable to format codeblock in Markdown or AsciiDoc etc.
+  codeblock: 1
 textRules:
   # No default text rules.
 spellcheck:

--- a/autocorrect/src/config/mod.rs
+++ b/autocorrect/src/config/mod.rs
@@ -10,7 +10,8 @@ use std::{
     collections::HashMap,
     fs,
     path::Path,
-    sync::{Arc, RwLock, RwLockReadGuard},
+    rc::Rc,
+    sync::{RwLock, RwLockReadGuard},
 };
 
 use crate::serde_any;
@@ -45,7 +46,7 @@ impl ConfigFileTypes for HashMap<String, String> {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default)]
@@ -58,17 +59,6 @@ pub struct Config {
     // Addition file types map, high priority than default
     #[serde(default)]
     pub file_types: HashMap<String, String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Config {
-            rules: HashMap::new(),
-            text_rules: HashMap::new(),
-            spellcheck: SpellcheckConfig::default(),
-            file_types: HashMap::new(),
-        }
-    }
 }
 
 pub fn load_file(config_file: &str) -> Result<Config, Error> {
@@ -132,8 +122,8 @@ impl From<std::string::String> for Error {
 }
 
 impl Config {
-    pub fn current() -> Arc<RwLockReadGuard<'static, Config>> {
-        Arc::new(CURRENT_CONFIG.read().unwrap())
+    pub fn current() -> Rc<RwLockReadGuard<'static, Config>> {
+        Rc::new(CURRENT_CONFIG.read().unwrap())
     }
 
     pub fn get_file_type(&self, ext: &str) -> Option<&str> {

--- a/autocorrect/src/config/severity.rs
+++ b/autocorrect/src/config/severity.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize, Serializer};
 
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub enum SeverityMode {
+    #[default]
     Off = 0,
     Error = 1,
     Warning = 2,

--- a/autocorrect/src/keyword.rs
+++ b/autocorrect/src/keyword.rs
@@ -155,7 +155,7 @@ impl Node {
                 c
             };
 
-            while node.children.get(&c).is_none() {
+            while !node.children.contains_key(&c) {
                 if node.fail.is_none() {
                     node = self;
                     break;

--- a/autocorrect/src/result/json.rs
+++ b/autocorrect/src/result/json.rs
@@ -21,7 +21,7 @@ pub(crate) fn crate_test_lint_results() -> Vec<LintResult> {
     let mut lint_result = LintResult::new("hello你好.\n这是第2行");
     lint_result.line = 10;
     lint_result.col = 12;
-    lint_result.filepath = "./test/foo/bar.rs".to_owned();
+    lint_result.filepath = "./test/foo/bar.rs".to_string();
     lint_result.push(LineResult {
         line: 1,
         col: 1,

--- a/autocorrect/src/result/mod.rs
+++ b/autocorrect/src/result/mod.rs
@@ -5,18 +5,13 @@ use serde_repr::*;
 
 use crate::config::toggle;
 
-#[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Eq, Debug, Default, Clone, Copy)]
 #[repr(u8)]
 pub enum Severity {
+    #[default]
     Pass = 0,
     Error = 1,
     Warning = 2,
-}
-
-impl Default for Severity {
-    fn default() -> Self {
-        Severity::Pass
-    }
 }
 
 impl Severity {
@@ -146,7 +141,7 @@ impl Results for FormatResult {
 
     fn error(&mut self, err: &str) {
         // Revert out to raw when has error, make sure return raw value.
-        self.out = self.raw.clone();
+        self.out = String::from(&self.raw);
         self.error = String::from(err);
     }
 

--- a/autocorrect/src/result/rdjson.rs
+++ b/autocorrect/src/result/rdjson.rs
@@ -114,8 +114,7 @@ pub(crate) fn to_rdjson_diagnostics(lint_result: &LintResult) -> Vec<String> {
 pub fn to_lint_results_rdjson(lint_results: Vec<LintResult>) -> String {
     let diagnostics = lint_results
         .iter()
-        .map(|r| to_rdjson_diagnostics(r))
-        .flatten()
+        .flat_map(to_rdjson_diagnostics)
         .collect::<Vec<_>>()
         .join(",");
     format!(

--- a/autocorrect/src/rule/fullwidth.rs
+++ b/autocorrect/src/rule/fullwidth.rs
@@ -31,8 +31,8 @@ lazy_static! {
 }
 
 // fullwidth correct punctuations near the CJK chars
-pub fn format<'h>(text: &'h str) -> String {
-    let out = PUNCTUATION_WITH_LEFT_CJK_RE.replace_all(&text, |cap: &regex::Captures| {
+pub fn format(text: &str) -> String {
+    let out = PUNCTUATION_WITH_LEFT_CJK_RE.replace_all(text, |cap: &regex::Captures| {
         fullwidth_replace_part(&cap[0])
     });
 

--- a/autocorrect/src/rule/mod.rs
+++ b/autocorrect/src/rule/mod.rs
@@ -281,6 +281,10 @@ mod tests {
             "hello你好 “Quote” 和 ‘Single Quote’ 测试1" => (map!{}, "hello 你好“Quote”和‘Single Quote’测试 1"),
             "你好-世界" => (map!{}, "你好 - 世界"),
             "世界-你好" => (map!{"space-dash" => true}, "世界-你好"),
+            "1你好[世界]" => (map!{ }, "1 你好 [世界]"),
+            "2你好[世界]" => (map!{ "space-bracket" => true }, "2 你好[世界]"),
+            "代码`code`例子1" => (map!{}, "代码 `code` 例子 1"),
+            "代码`code`例子2" => (map!{ "space-backticks" => true }, "代码`code`例子 2"),
         };
 
         for (input, (disable_rules, expect)) in cases {

--- a/autocorrect/src/rule/word.rs
+++ b/autocorrect/src/rule/word.rs
@@ -119,7 +119,7 @@ pub fn format_no_space_fullwidth_quote(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::rule::word::{format_space_backticks, format_space_dash};
+    use crate::rule::word::{format_space_backticks, format_space_bracket, format_space_dash};
 
     #[test]
     fn test_format_space_dash() {
@@ -127,6 +127,15 @@ mod tests {
         assert_eq!(format_space_dash("foo-世界"), "foo-世界");
         assert_eq!(format_space_dash("你好-world"), "你好-world");
         assert_eq!(format_space_dash("hello-world"), "hello-world");
+    }
+
+    #[test]
+    fn test_format_space_bracket() {
+        assert_eq!(format_space_bracket("你好[世界]"), "你好 [世界]");
+        assert_eq!(format_space_bracket("你好(世界)"), "你好 (世界)");
+        assert_eq!(format_space_bracket("foo[世界"), "foo[世界");
+        assert_eq!(format_space_bracket("你好]world"), "你好]world");
+        assert_eq!(format_space_bracket("hello]world"), "hello]world");
     }
 
     #[test]


### PR DESCRIPTION
In `.autocorrectrc`

```yml
# Enable or disable in spatial context
context:
  # Enable or disable to format codeblock in Markdown or AsciiDoc etc.
  codeblock: 1
```

Ref https://github.com/apache/eventmesh-site/pull/226/files#r1645701069