### PR TITLE
doc: Add use case for greptimedb

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ The other implementations from the community.
 - [Rust Book CN](https://kaisery.github.io/trpl-zh-cn)
 - [Ruby China](https://ruby-china.org)
 - [JuiceFS](https://juicefs.com)
+- [GreptimeDB](https://greptime.com)
 
 ## License
 


### PR DESCRIPTION
this patch  add greptimedb to the use case.

more can track this pull request: https://github.com/GreptimeTeam/docs/pull/1586