### PR TITLE
perf: Use Cow to avoid creates String on format.

### DIFF
--- a/autocorrect/src/format.rs
+++ b/autocorrect/src/format.rs
@@ -23,7 +23,7 @@ use crate::{
 /// // => "既に、世界中の数百という企業が Rust を採用し、高速で低リソースのクロスプラットフォームソリューションを実現しています。"
 /// ```
 pub fn format(text: &str) -> String {
-    format_or_lint(text, false).out
+    format_or_lint(text, false).out.into_owned()
 }
 
 /// Format a html content.

--- a/autocorrect/src/rule/halfwidth.rs
+++ b/autocorrect/src/rule/halfwidth.rs
@@ -131,6 +131,7 @@ pub fn format_punctuation(text: &str) -> Cow<str> {
     }
 }
 
+/// Normalize chars to use general half width in Chinese contents.
 pub fn format_word(text: &str) -> Cow<str> {
     let mut changed = false;
     let out = text

--- a/autocorrect/src/rule/word.rs
+++ b/autocorrect/src/rule/word.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 // autocorrect: false
 use super::{strategery::Strategery, CJK_RE};
 
@@ -55,66 +57,75 @@ lazy_static! {
     ];
 }
 
-pub fn format_space_word(input: &str) -> String {
-    let mut out = String::from(input);
-    WORD_STRATEGIES.iter().for_each(|s| out = s.format(&out));
-    out
+pub fn format_space_word(input: &str) -> Cow<str> {
+    WORD_STRATEGIES
+        .iter()
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_space_punctuation(input: &str) -> String {
-    let mut out = String::from(input);
+pub fn format_space_punctuation(input: &str) -> Cow<str> {
     PUNCTUATION_STRATEGIES
         .iter()
-        .for_each(|s| out = s.format(&out));
-    out
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_space_bracket(input: &str) -> String {
-    let mut out = String::from(input);
+pub fn format_space_bracket(input: &str) -> Cow<str> {
     BRACKETS_STRATEGIES
         .iter()
-        .for_each(|s| out = s.format(&out));
-    out
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_space_dash(input: &str) -> String {
-    let mut out = String::from(input);
-    DASH_STRATEGIES.iter().for_each(|s| out = s.format(&out));
-    out
+pub fn format_space_dash(input: &str) -> Cow<str> {
+    DASH_STRATEGIES
+        .iter()
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_space_backticks(input: &str) -> String {
-    let mut out = String::from(input);
+pub fn format_space_backticks(input: &str) -> Cow<str> {
     BACKTICKS_STRATEGIES
         .iter()
-        .for_each(|s| out = s.format(&out));
-    out
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_no_space_fullwidth(input: &str) -> String {
-    let mut out = String::from(input);
-
+pub fn format_no_space_fullwidth(input: &str) -> Cow<str> {
     if !CJK_RE.is_match(input) {
-        return out;
+        return Cow::Borrowed(input);
     }
 
     NO_SPACE_FULLWIDTH_STRATEGIES
         .iter()
-        .for_each(|s| out = s.format(&out));
-    out
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
-pub fn format_no_space_fullwidth_quote(input: &str) -> String {
-    let mut out = String::from(input);
-
+pub fn format_no_space_fullwidth_quote(input: &str) -> Cow<str> {
     if !CJK_RE.is_match(input) {
-        return out;
+        return Cow::Borrowed(input);
     }
 
     NO_SPACE_FULLWIDTH_QUOTE_STRATEGIES
         .iter()
-        .for_each(|s| out = s.format(&out));
-    out
+        .fold(Cow::Borrowed(input), |text, strategy| match text {
+            Cow::Borrowed(s) => strategy.format(s),
+            Cow::Owned(s) => Cow::Owned(strategy.format(&s).into_owned()),
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request focuses on improving the performance and memory usage of the formatting functions by changing their return types to `Cow<str>`. This allows the functions to return either borrowed or owned data, reducing unnecessary allocations when the input is not modified. 

Most benchmarks gain 10% ~ 20% improvement on my local PC:

```
format_json             time:   [171.73 µs 172.00 µs 172.28 µs]
                        change: [-17.792% -17.409% -17.049%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

format_javascript       time:   [360.43 µs 360.88 µs 361.32 µs]
                        change: [-15.179% -13.906% -12.966%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

format_json_2k          time:   [21.865 ms 21.882 ms 21.900 ms]
                        change: [-15.133% -14.999% -14.869%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

format_jupyter          time:   [275.67 µs 276.03 µs 276.38 µs]
                        change: [-7.5263% -7.2771% -7.0001%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

format_markdown         time:   [2.2873 ms 2.2896 ms 2.2923 ms]
                        change: [-14.583% -14.448% -14.325%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

lint_markdown           time:   [2.3867 ms 2.3939 ms 2.4021 ms]
                        change: [-15.337% -15.092% -14.799%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

lint_json               time:   [180.12 µs 180.38 µs 180.64 µs]
                        change: [-19.382% -18.912% -18.449%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

lint_html               time:   [694.02 µs 694.96 µs 695.95 µs]
                        change: [-15.000% -14.666% -14.362%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

lint_javascript         time:   [367.04 µs 367.55 µs 368.05 µs]
                        change: [-27.115% -23.420% -20.369%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)

```