### PR TITLE
doc: Update benchmark result.

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,28 +437,28 @@ Use `make bench` to run benchmark tests.
 See [autocorrect/src/benches/example.rs](https://github.com/huacnlee/autocorrect/blob/main/autocorrect/src/benches/example.rs) for details.
 
 ```bash
-format_050              time:   [8.2420 µs 8.2657 µs 8.2937 µs]
-format_100              time:   [14.199 µs 14.246 µs 14.298 µs]
-format_400              time:   [40.511 µs 41.923 µs 43.798 µs]
-format_html             time:   [204.94 µs 208.61 µs 214.07 µs]
-halfwidth_english       time:   [2.4983 µs 2.5541 µs 2.6293 µs]
-format_json             time:   [54.037 µs 57.023 µs 61.821 µs]
-format_javascript       time:   [102.81 µs 104.41 µs 106.92 µs]
-format_json_2k          time:   [8.7609 ms 8.9099 ms 9.1201 ms]
-format_jupyter          time:   [81.765 µs 83.038 µs 85.321 µs]
-format_markdown         time:   [879.27 µs 894.86 µs 918.30 µs]
+format_050              time:   [4.9991 µs 5.0175 µs 5.0382 µs]
+format_100              time:   [8.7714 µs 8.8236 µs 8.8896 µs]
+format_400              time:   [23.535 µs 23.591 µs 23.666 µs]
+format_html             time:   [332.87 µs 334.00 µs 335.37 µs]
+halfwidth_english       time:   [1.2051 µs 1.2079 µs 1.2110 µs]
+format_json             time:   [54.019 µs 54.345 µs 54.855 µs]
+format_javascript       time:   [176.61 µs 181.64 µs 187.20 µs]
+format_json_2k          time:   [9.3245 ms 9.3768 ms 9.4390 ms]
+format_jupyter          time:   [200.77 µs 204.93 µs 210.91 µs]
+format_markdown         time:   [1.2216 ms 1.2246 ms 1.2283 ms]
 
-spellcheck_50           time:   [1.6012 µs 1.6122 µs 1.6306 µs]
-spellcheck_100          time:   [3.0968 µs 3.1696 µs 3.2653 µs]
-spellcheck_400          time:   [10.136 µs 10.478 µs 10.898 µs]
+spellcheck_50           time:   [1.2098 µs 1.2162 µs 1.2234 µs]
+spellcheck_100          time:   [2.2592 µs 2.3049 µs 2.3861 µs]
+spellcheck_400          time:   [7.7480 µs 7.9111 µs 8.1764 µs]
 
-lint_markdown           time:   [937.57 µs 942.59 µs 949.15 µs]
-lint_json               time:   [59.174 µs 60.302 µs 61.763 µs]
-lint_html               time:   [238.03 µs 241.38 µs 245.77 µs]
-lint_javascript         time:   [111.64 µs 113.05 µs 114.82 µs]
-lint_yaml               time:   [348.56 µs 350.11 µs 352.80 µs]
-lint_to_json            time:   [941.25 µs 948.95 µs 958.26 µs]
-lint_to_diff            time:   [1.0573 ms 1.0823 ms 1.1134 ms]
+lint_markdown           time:   [1.2704 ms 1.2883 ms 1.3173 ms]
+lint_json               time:   [58.696 µs 60.847 µs 63.484 µs]
+lint_html               time:   [448.53 µs 486.95 µs 534.01 µs]
+lint_javascript         time:   [177.00 µs 177.88 µs 178.69 µs]
+lint_yaml               time:   [378.35 µs 382.30 µs 387.85 µs]
+lint_to_json            time:   [1.2629 ms 1.2689 ms 1.2769 ms]
+lint_to_diff            time:   [1.3255 ms 1.3288 ms 1.3327 ms]
 ```
 
 ### Real world benchmark

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ AutoCorrect makes for support use in many programming languages.
 
 ## Benchmark
 
-> MacBook Pro (13-inch, M1, 2020)
+> MacBook Pro (13-inch, Apple M3, 2023)
 
 Use `make bench` to run benchmark tests.
 

--- a/README.md
+++ b/README.md
@@ -357,9 +357,7 @@ function hello() {
 
 https://marketplace.visualstudio.com/items?itemName=huacnlee.autocorrect
 
-内置 Visual Studio Code 插件，安装后会将 AutoCorrect 和 Visual Studio Code 完整集成，可以达到「保存自动格式化」或「纠正提示」。
-
-如下图：
+Screenshot:
 
 <img width="900" alt="AutoCorrect for VS Code Extension" src="https://user-images.githubusercontent.com/5518/191890126-4e0c99dc-91ce-4262-a774-3813a636eea1.png">
 


### PR DESCRIPTION
Recent changes, we get: 10% ~ 30% performance improvement, and `halfwidth` get 50% improvement.

```
format_050              time:   [5.0593 µs 5.0903 µs 5.1375 µs]
                        change: [-20.855% -20.397% -19.808%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

format_100              time:   [8.6155 µs 8.6380 µs 8.6626 µs]
                        change: [-21.281% -20.865% -20.394%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

format_400              time:   [23.488 µs 23.503 µs 23.520 µs]
                        change: [-23.933% -23.332% -22.808%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

format_html             time:   [333.56 µs 334.31 µs 335.28 µs]
                        change: [-4.9896% -4.7014% -4.4106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

halfwidth_english       time:   [989.11 ns 998.18 ns 1.0092 µs]
                        change: [-52.047% -51.654% -51.169%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  12 (12.00%) high severe

format_json             time:   [53.582 µs 53.845 µs 54.249 µs]
                        change: [-12.689% -11.898% -11.134%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

format_javascript       time:   [173.77 µs 174.53 µs 175.48 µs]
                        change: [-3.9643% -3.3952% -2.5339%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

format_json_2k          time:   [8.8331 ms 8.8477 ms 8.8666 ms]
                        change: [-16.542% -16.064% -15.683%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

format_jupyter          time:   [194.61 µs 194.80 µs 195.02 µs]
                        change: [-6.0811% -5.2462% -4.4798%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

format_markdown         time:   [1.2318 ms 1.2576 ms 1.2907 ms]
                        change: [-7.1730% -6.4374% -5.4945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  3 (3.00%) high mild
  15 (15.00%) high severe

spellcheck_50           time:   [1.1976 µs 1.2004 µs 1.2037 µs]
                        change: [-11.644% -11.236% -10.855%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

spellcheck_100          time:   [2.3332 µs 2.3822 µs 2.4342 µs]
                        change: [-10.841% -9.7377% -8.5275%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

spellcheck_400          time:   [7.6525 µs 7.6892 µs 7.7337 µs]
                        change: [-6.7812% -6.1409% -5.4214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

lint_markdown           time:   [1.3219 ms 1.3412 ms 1.3641 ms]
                        change: [-3.9642% -1.0184% +2.1326%] (p = 0.52 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

lint_json               time:   [58.524 µs 58.805 µs 59.145 µs]
                        change: [-8.9511% -8.4724% -7.9769%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

lint_html               time:   [353.92 µs 360.32 µs 371.64 µs]
                        change: [-6.3317% -5.6190% -4.5049%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

lint_javascript         time:   [181.06 µs 183.88 µs 187.68 µs]
                        change: [-1.9953% -0.2524% +2.0506%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

lint_yaml               time:   [375.97 µs 377.38 µs 379.46 µs]
                        change: [-12.032% -11.410% -10.886%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

lint_to_json            time:   [1.2790 ms 1.2891 ms 1.3037 ms]
                        change: [-4.0166% -2.4721% -0.4510%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

lint_to_diff            time:   [1.3725 ms 1.3984 ms 1.4333 ms]
                        change: [-5.0878% -2.5981% +0.3373%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
```

> NOTE: Value from af1dd595e74303c6e9e94357f47406585d8e9cd0 vs d6ea7c1bf87630d92976ba57207817aae0b2b618 at same computer, not only the README result diff.

@quake 