### PR TITLE
fix: support python double quote regexp

### DIFF
--- a/autocorrect/grammar/python.pest
+++ b/autocorrect/grammar/python.pest
@@ -21,5 +21,6 @@ inner_string = _{
 regexp = ${
     ("r'" ~ (!(NEWLINE | "'") ~ ANY)* ~ "'")
   | ("r\"\"\"" ~ (!("\"\"\"") ~ ANY)* ~ "\"\"\"")
+  | ("r\"" ~ (!(NEWLINE | "\"") ~ ANY)* ~ "\"")
   | ("compile(" ~ " "* ~ inner_string ~ (!")" ~ ANY)* ~ ")")
 }


### PR DESCRIPTION
This pull request add double quote regex support in python, like `r".*"`.