### PR TITLE
Fix to correctly parse Obsidian-style ![[img]], skip internal text formatting

### DIFF
--- a/autocorrect/grammar/markdown.pest
+++ b/autocorrect/grammar/markdown.pest
@@ -94,7 +94,7 @@ meta_tags_val     = @{ meta_tags_item ~ meta_tags_divider }
 meta_tags_item    =  { (!(newline | ",") ~ (CJK | " " | ASCII_ALPHANUMERIC))* }
 meta_tags_divider =  { " "* ~ "," ~ " "* }
 image_prefix      = @{ "!" }
-img               = ${ image_prefix ~ link }
+img               = ${ image_prefix ~ (wikilinks | link) }
 
 /// Matches link, e.g.: `[Hello](/hello)` or `[Hello]`
 link             = ${ link_string_wrap ~ href? }

--- a/autocorrect/src/code/markdown.rs
+++ b/autocorrect/src/code/markdown.rs
@@ -155,6 +155,7 @@ mod tests {
         - [link链接](https://google.com/a/b/url不处理)
         - Escher puzzle（[链接](https://google.com)）
         - 一个[[Wikilinks测试]]示例
+        - 一个![[obsidian style img测试.png]]示例
 
         请记住:对该仓库的贡献,应遵循我们的GitHub社区准则。
 
@@ -295,6 +296,7 @@ mod tests {
         - [link 链接](https://google.com/a/b/url不处理)
         - Escher puzzle（[链接](https://google.com)）
         - 一个[[Wikilinks测试]]示例
+        - 一个![[obsidian style img测试.png]]示例
 
         请记住：对该仓库的贡献，应遵循我们的 GitHub 社区准则。
 


### PR DESCRIPTION
- Refine pest grammar so `img = ${ image_prefix ~ (wikilinks | link) }`
- Ensures both Obsidian-style images `![[...]]` and standard images are correctly parsed as img, preventing over-formatting inner text
- Added test for obsidian-style image

Indeed, this is just a dialect of markdown. But since we've already supported wikilinks and implementing this is as simple as one line modification in markdown.pest, I just did it.