### PR TITLE
Fix core: harden config and fullwidth paths

### DIFF
--- a/autocorrect/src/code/types.rs
+++ b/autocorrect/src/code/types.rs
@@ -25,9 +25,9 @@ pub fn get_file_extension(filename: &str) -> String {
         return String::from(filename);
     }
 
-    let filename = filename.split('/').next_back().unwrap().to_string();
+    let filename = filename.split('/').next_back().unwrap_or(filename).to_string();
     let path_parts: Vec<&str> = filename.split('.').collect();
-    let mut ext: String = path_parts.last().unwrap().to_string();
+    let mut ext: String = path_parts.last().unwrap_or(&"").to_string();
 
     let part_len = path_parts.len();
     if part_len > 2 {


### PR DESCRIPTION
Improve error context on config lock failures.
Handle empty filenames safely in get_file_extension. Inline fullwidth mapping to keep behavior explicit and predictable. No behavior change expected in normal cases; adds clearer diagnostics and edge-case guards.

GitHub Copilot summary:

> This pull request focuses on improving code safety, clarity, and maintainability by refining error handling, removing unnecessary data structures, and making code more robust against edge cases. The most significant changes are grouped below:
> 
> ### Error Handling Improvements
> 
> * Replaced all `unwrap()` calls on lock acquisition for `CURRENT_CONFIG` with `expect()` calls that provide explicit error messages, making failures easier to debug. (`autocorrect/src/config/mod.rs`) [[1]](diffhunk://#diff-ae87829b949516897ee55b6cae0978ff11fea833c8550007114392aa55309b57L84-R87) [[2]](diffhunk://#diff-ae87829b949516897ee55b6cae0978ff11fea833c8550007114392aa55309b57L132-R139)
> 
> ### Code Robustness
> 
> * Updated the `get_file_extension` function to use `unwrap_or` instead of `unwrap` when splitting filenames and extracting extensions, which prevents panics on unexpected input. (`autocorrect/src/code/types.rs`)
> 
> ### Code Simplification and Performance
> 
> * Removed the `FULLWIDTH_MAPS` `HashMap` and replaced it with a direct match statement in `fullwidth_replace_part`, reducing overhead and improving code clarity. (`autocorrect/src/rule/fullwidth.rs`) [[1]](diffhunk://#diff-9f98338e01c0ea8421e76a219bf5e90b44832c6df867ef2d223de827ac400a95L3-L16) [[2]](diffhunk://#diff-9f98338e01c0ea8421e76a219bf5e90b44832c6df867ef2d223de827ac400a95L60-R70)
> 
> ### Minor Refactoring
> 
> * Changed the `merge` method in `Config` to iterate over references and clone keys/values as needed, improving efficiency and code readability. (`autocorrect/src/config/mod.rs`)