### PR TITLE
Fix aarch64 architecture identification

### DIFF
--- a/install
+++ b/install
@@ -12,7 +12,7 @@ repo='huacnlee/autocorrect'
 bin_name='autocorrect'
 version=`get_latest_release`
 platform="$(uname | tr "[A-Z]" "[a-z]")"  # Linux => linux
-arch="$(uname -m | sed 's/x86_64/amd64/')"  # x86_64 => amd64
+arch="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"  # x86_64 => amd64 | aarch64 => arm64
 
 echo "Downloading $bin_name@$version ..."
 


### PR DESCRIPTION
修复 aarch64 架构，使用 install 脚本安装，下载发行版失败问题